### PR TITLE
Upgrade to Treasury Release 0.15.0

### DIFF
--- a/org.goldcoinproject.goldcoin-qt.json
+++ b/org.goldcoinproject.goldcoin-qt.json
@@ -26,8 +26,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/goldcoin/goldcoin/releases/download/v0.14.9.5/goldcoin-0.14.9.5-x86_64-linux-gnu.tar.gz",
-          "sha256": "61331ebc2780229e4df94f2ca75da9ce51614b2d1022638f8895a34d713432de"
+          "url": "https://github.com/goldcoin/goldcoin/releases/download/v0.15.0/goldcoin-0.15.0-x86_64-linux-gnu.tar.gz",
+          "sha256": "66ed763461c9368887bb657c0d7ad6247e6ad956419483b558dc97877bcec0b8"
         }
       ]
     },

--- a/org.goldcoinproject.goldcoin-qt.metainfo.xml
+++ b/org.goldcoinproject.goldcoin-qt.metainfo.xml
@@ -22,6 +22,7 @@
   <update_contact>kbicer@proton.me</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2023-08-20" version="0.15.0" />
     <release date="2023-01-14" version="0.14.9.5" />
     <release date="2022-11-16" version="0.14.9" />
     <release date="2021-07-16" version="0.14.8" />


### PR DESCRIPTION
This upgrade is a simple consensus rules update that will fund a treasury with 1.1 billion GLC by means of a superblock. The coins will be immediately locked in a multi-sig protected wallet and not available to markets. A board of directors will decide the timing of any and all expenditures (or future coin buybacks).